### PR TITLE
Support for ruby 2.4.0

### DIFF
--- a/profitbricks-sdk-ruby.gemspec
+++ b/profitbricks-sdk-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "excon", "~> 0.44"
-  spec.add_runtime_dependency "json", "~> 1.8"
+  spec.add_runtime_dependency "json"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
json >= 2.0 is required for ruby 2.4.0

json (1.8.3) for ruby 2.4.0:

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
~/.rvm/gems/ruby-2.4.0/gems/json-1.8.3/ext/json/ext/generator
 ~/.rvm/rubies/ruby-2.4.0/bin/ruby -r ./siteconf20161231-19634-1pqcdu4.rb
extconf.rb
creating Makefile

current directory:
~/.rvm/gems/ruby-2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean

current directory:
~/.rvm/gems/ruby-2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c: In function ‘generate_json’:
generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function)
     } else if (klass == rb_cFixnum) {
                         ^
generator.c:861:25: note: each undeclared identifier is reported only once for each
function it appears in
generator.c:863:25: error: ‘rb_cBignum’ undeclared (first use in this function)
     } else if (klass == rb_cBignum) {
                         ^
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in
~/.rvm/gems/ruby-2.4.0/gems/json-1.8.3 for inspection.
Results logged to
~/.rvm/gems/ruby-2.4.0/extensions/x86_64-linux/2.4.0/json-1.8.3/gem_make.out

An error occurred while installing json (1.8.3), and Bundler cannot
continue.
Make sure that `gem install json -v '1.8.3'` succeeds before bundling.