### PR TITLE
Model#reload - raises Excon::Error::NotFound

### DIFF
--- a/lib/profitbricks/model.rb
+++ b/lib/profitbricks/model.rb
@@ -27,8 +27,14 @@ module ProfitBricks
 
     def reload
       # Remove URL host and prefix path from href.
+      # Example: server
       path = URI(self.href).path
+      # => /cloudapi/v3/datacenters/UUID/servers/UUID
       path.sub!(ProfitBricks::Config.path_prefix, '')
+      # => //datacenters/UUID/servers/UUID
+      # => raises Excon::Error::NotFound
+      path.sub!(/\/{2,}/, '/')
+      # => /datacenters/UUID/servers/UUID
       
       response = ProfitBricks.request(
         method: :get,


### PR DESCRIPTION
After the ProfitBricks::Config.path_prefix is removed from the path, the path starts with '//'.
This raises Excon::Error::NotFound!

The method works, if the // replaced with one /.